### PR TITLE
Add AddQuestionPage and update add_question logics to support translations

### DIFF
--- a/backend/data_handler_app/admin.py
+++ b/backend/data_handler_app/admin.py
@@ -16,29 +16,30 @@ def add_question_handler(request):
     return render(request, 'add_question_form.html')
 
 def add_question(request):
-    if request.method == 'POST':
-        try:
-            question = request.POST.get('question')
-            answer_choices = request.POST.get('answers').split(',')
-            has_other = False if request.POST.get('has_other') == 'false' else True
+    print(request.POST)
+    # if request.method == 'POST':
+    #     try:
+    #         question = request.POST.get('question')
+    #         answer_choices = request.POST.get('answers').split(',')
+    #         has_other = False if request.POST.get('has_other') == 'false' else True
 
-            data = {
-                'deleted': False,
-                'question': question,
-                'answer_choices': answer_choices,
-                'has_other': has_other,
-            }
-            print(data)
-        except Exception as e:
-            return JsonResponse({"status": "error", "message":f"Error parsing form data: {str(e)}"}, 
-                                status=400)
+    #         data = {
+    #             'deleted': False,
+    #             'question': question,
+    #             'answer_choices': answer_choices,
+    #             'has_other': has_other,
+    #         }
+    #         print(data)
+    #     except Exception as e:
+    #         return JsonResponse({"status": "error", "message":f"Error parsing form data: {str(e)}"}, 
+    #                             status=400)
         
-        try:
-            # Save new question
-            question = Question(**data)
-            question.save()
-        except:
-            return JsonResponse({'error': 'not valid JSON data'})
+    #     try:
+    #         # Save new question
+    #         question = Question(**data)
+    #         question.save()
+    #     except:
+    #         return JsonResponse({'error': 'not valid JSON data'})
     
     return JsonResponse({'message': 'successfully added a new question'})  
 

--- a/backend/data_handler_app/urls.py
+++ b/backend/data_handler_app/urls.py
@@ -1,11 +1,14 @@
 from django.urls import path
-from .views import client_data_list, client_data_form, get_questions
+from .views import client_data_list, client_data_form, get_questions, get_languages, get_question_translations, get_answers_translations
 from .admin import admin_panel, add_question_handler, add_question, update_question_handler, update_question, submit_update
 
 urlpatterns = [
     path('clientdata/', client_data_list, name='client_data_list'),
     path('newsubmission/', client_data_form, name='new_submission'),
     path('questions/', get_questions, name='questions'),
+    path('languages/', get_languages, name='get_languages'),
+    path('translations/question/<str:question>/', get_question_translations, name='get_question_translations'),
+    path('translations/answers/<str:answers>/', get_answers_translations, name='get_answers_translations'),
     path('adminpanel/', admin_panel, name='admin_panel'),
     path('addquestion/form/', add_question_handler, name = 'add_question_handler'),
     path('addquestion/submit/', add_question, name='add_question'),

--- a/backend/data_handler_app/views.py
+++ b/backend/data_handler_app/views.py
@@ -3,8 +3,10 @@ from django.shortcuts import render
 from django.http import JsonResponse
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from .models import Answer, Question
+from .models import Answer, Question, Language
 import json
+import translators as ts
+
 # Create your views here.
 
 @csrf_exempt
@@ -71,3 +73,32 @@ def client_data_list(request):
 def get_questions(request):
     questions = list(Question.objects.values())
     return JsonResponse(questions, safe=False)
+
+def get_languages(request):
+    languages = list(Language.objects.values())
+    return JsonResponse(languages, safe=False)
+
+def get_question_translations(request, question):
+    lang_abbrev = list(Language.objects.values("abbreviation"))
+    translation_dict = {}
+
+    for lang in lang_abbrev:
+        translation = ts.translate_text(question, translator="google", to_language=lang['abbreviation'].lower())
+        translation_dict[lang['abbreviation']] = translation
+    
+    return JsonResponse(translation_dict, safe=False)
+
+def get_answers_translations(request, answers):
+    lang_abbrev = list(Language.objects.values("abbreviation"))
+    translation_dict = {}
+    answers = answers.strip().split(",")
+
+    for lang in lang_abbrev:
+        translation_arr = []
+        for answer in answers:
+            translation = ts.translate_text(answer, translator="google", to_language=lang['abbreviation'].lower())
+            translation_arr.append(translation)
+        translation_str = ','.join(translation_arr)
+        translation_dict[lang['abbreviation']] = translation_str
+    
+    return JsonResponse(translation_dict, safe=False)

--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -3,10 +3,11 @@ import axios from 'axios';
 
 const AddQuestionPage = () => {
     const [allLanguages, setallLanguages] = useState([]);
-    // const [question, setQuestion] = useState("");
-    // const [answers, setAnswers] = useState("");
+    const [question, setQuestion] = useState("");
+    const [answers, setAnswers] = useState("");
     const [translatedQuestions, setTranslatedQuestions] = useState({});
     const [translatedAnswers, setTranslatedAnswers] = useState({});
+    const [translatedOthers, setTranslatedOther] = useState({});
 
     // Fetch language data
     useEffect(() => {
@@ -21,8 +22,7 @@ const AddQuestionPage = () => {
     }, []);
 
     // A function to fetch the translations after user enters a question
-    const getQuestionTranslations = (e) => {
-        const question = e.target.value;
+    const getQuestionTranslations = () => {
         axios.get(`http://127.0.0.1:8000/translations/question/${question}/`)
         .then(response => {
             setTranslatedQuestions(response.data);
@@ -33,9 +33,7 @@ const AddQuestionPage = () => {
       };
 
     // A function to fetch the translations after user enters answer choices
-    const getAnswersTranslations = (e) => {
-        const answers = e.target.value;
-        // const data = {question: question, answers: answers}
+    const getAnswersTranslations = () => {
         axios.get(`http://127.0.0.1:8000/translations/answers/${answers}/`)
         .then(response => {
             setTranslatedAnswers(response.data);
@@ -45,15 +43,72 @@ const AddQuestionPage = () => {
         });
     };
 
-    function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers) {
+    // A function to fetch the translations for the word "Other"
+    const getOtherTranslations = () => {
+        axios.get(`http://127.0.0.1:8000/translations/question/other/`)
+        .then(response => {
+            setTranslatedOther(response.data);
+        })
+        .catch(error => {
+            console.error('Error fetching data:', error);
+        });
+    };
+
+    // A function to handle whether to translate "Other" or not
+    const handleHasOtherClick = (e) => {
+        const val = e.target.value;
+        
+        if (val === "true") {
+            getOtherTranslations();
+        }
+        else {
+            setTranslatedOther({});
+        }
+    }
+
+    const handleSubmit = async(e) => {
+        e.preventDefault();
+
+        const form_data = new FormData(e.target);
+        const form_data_object = {};
+
+        form_data.forEach((value, key) => {
+            form_data_object[key] = value;
+        });
+
+        const json_data = JSON.stringify(form_data_object);
+
+        axios.post("http://127.0.0.1:8000/addquestion/submit/", json_data, 
+        {
+            headers: {
+            "Content-Type": "application/json",
+            },
+        })
+        .then((response) => {
+            if (response.status === 200) {
+                console.log("status", response.status);
+            } 
+            else {
+                console.log("unsuccessful");
+            }
+        })
+        .catch((error) => {
+            console.error("Error sending data", error);
+        });
+    }
+
+    function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers) {
         if (allLanguages.length !== 0) {
             return allLanguages.map(obj => {
-                return <div className="row" key={`lang-${obj.abbreviation}`}>
-                            <label htmlFor={`lang-${obj.abbreviation}-question`}>{`${obj.name} Question:`}</label>
-                            <input type="text" id={`lang-${obj.abbreviation}-question`} name={`lang-${obj.abbreviation}-question`}
+                return <div className="row py-3" key={`${obj.abbreviation}`}>
+                            <label htmlFor={`${obj.abbreviation}-question`}>{`${obj.name} Question:`}</label>
+                            <input type="text" id={`${obj.abbreviation}-question`} name={`${obj.abbreviation}-question`}
                             defaultValue={translatedQuestions[obj.abbreviation] ? `${translatedQuestions[obj.abbreviation]}` : ""}/>
-                            <label htmlFor={`lang-${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</label>
-                            <input type="text" id={`lang-${obj.abbreviation}-answers`} name={`lang-${obj.abbreviation}-answers`}
+                            <label htmlFor={`${obj.abbreviation}-other`}>{`${obj.name} "Other":`}</label>
+                            <input type="text" id={`${obj.abbreviation}-other`} name={`${obj.abbreviation}-other`}
+                            defaultValue={translatedOthers[obj.abbreviation] ? `${translatedOthers[obj.abbreviation]}` : ""}/>
+                            <label htmlFor={`${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</label>
+                            <input type="text" id={`${obj.abbreviation}-answers`} name={`${obj.abbreviation}-answers`}
                             defaultValue={translatedAnswers[obj.abbreviation] ? `${translatedAnswers[obj.abbreviation]}` : ""}/>
                        </div>
             })
@@ -62,47 +117,50 @@ const AddQuestionPage = () => {
 
     return (
         <div className="container">
-            <form action="/addquestion/submit/" method="post">
+            <form method="post" onSubmit={handleSubmit}>
                 <div className="row gap-5">
                     <div className="col">
-                        <div className="row">
+                        <div className="row py-3">
                             <label htmlFor="question">Question:</label>
-                            <input type="text" id="question" name="question" onBlur={getQuestionTranslations}/>
+                            <input type="text" id="question" name="question" onBlur={(e) => setQuestion(e.target.value)}/>
+                            <div className="col py-3">
+                                <button onClick={getQuestionTranslations}>Get Translation</button>
+                            </div>
                         </div>
-                        <div className="row">
+                        <div className="row py-3">
                             <label htmlFor="answers">Answers (comma-separated):</label>
-                            <input type="text" id="answers" name="answers" onBlur={getAnswersTranslations}/>
+                            <input type="text" id="answers" name="answers" onBlur={(e) => setAnswers(e.target.value)}/>
+                            <div className="col py-3">
+                                <button onClick={getAnswersTranslations}>Get Translation</button>
+                            </div>
                         </div>
-                        <div className="row">
+                        <div className="row py-3">
                             <div className="col">
                                 <div className="row">
                                     <label htmlFor="hasOther">Has Other:</label>
                                 </div>
                                 <div className="row">
                                     <div className="col">
-                                        <input type="radio" id="has_other_true" name="has_other" value="true" />
+                                        <input type="radio" id="has_other_true" name="has_other" value="true" onClick={handleHasOtherClick}/>
                                         <label htmlFor="has_other_true">True</label>
                                     </div>
                                 </div>
                                 <div className="row">
                                     <div className="col">
-                                        <input type="radio" id="has_other_false" name="has_other" value="false" />
+                                        <input type="radio" id="has_other_false" name="has_other" value="false" onClick={handleHasOtherClick}/>
                                         <label htmlFor="has_other_false">False</label>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div className="row">
+                        <div className="row py-3">
                             <div className="col">
                                 <button type="submit">Submit</button>
                             </div>
-                            {/* <div className="col">
-                                <button type="button" onClick={getTranslations}>Get Translation</button>
-                            </div> */}
                         </div>
                     </div>
                     <div className="col">
-                        {displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers)}
+                        {displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers)}
                     </div>
                 </div>
             </form>

--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -69,21 +69,21 @@ const AddQuestionPage = () => {
     const handleSubmit = async(e) => {
         e.preventDefault();
 
-        const form_data = new FormData(e.target);
-        const form_data_object = {};
+        const formData = new FormData(e.target);
+        const formDataObj = {};
 
-        form_data.forEach((value, key) => {
-            form_data_object[key] = value;
+        formData.forEach((value, key) => {
+            formDataObj[key] = value;
         });
+        const jsonData = JSON.stringify(formDataObj);
 
-        const json_data = JSON.stringify(form_data_object);
-
-        axios.post("http://127.0.0.1:8000/addquestion/submit/", json_data, 
-        {
-            headers: {
-            "Content-Type": "application/json",
-            },
-        })
+        axios.post("http://127.0.0.1:8000/addquestion/submit/", jsonData,
+            {
+                headers: {
+                    "Content-Type": "application/json"
+                },
+            }
+        )
         .then((response) => {
             if (response.status === 200) {
                 console.log("status", response.status);
@@ -124,14 +124,14 @@ const AddQuestionPage = () => {
                             <label htmlFor="question">Question:</label>
                             <input type="text" id="question" name="question" onBlur={(e) => setQuestion(e.target.value)}/>
                             <div className="col py-3">
-                                <button onClick={getQuestionTranslations}>Get Translation</button>
+                                <button type="button" onClick={getQuestionTranslations}>Get Translation</button>
                             </div>
                         </div>
                         <div className="row py-3">
                             <label htmlFor="answers">Answers (comma-separated):</label>
                             <input type="text" id="answers" name="answers" onBlur={(e) => setAnswers(e.target.value)}/>
                             <div className="col py-3">
-                                <button onClick={getAnswersTranslations}>Get Translation</button>
+                                <button type="button" onClick={getAnswersTranslations}>Get Translation</button>
                             </div>
                         </div>
                         <div className="row py-3">

--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const AddQuestionPage = () => {
+    const [allLanguages, setallLanguages] = useState([]);
+    // const [question, setQuestion] = useState("");
+    // const [answers, setAnswers] = useState("");
+    const [translatedQuestions, setTranslatedQuestions] = useState({});
+    const [translatedAnswers, setTranslatedAnswers] = useState({});
+
+    // Fetch language data
+    useEffect(() => {
+        console.log("App.js useEffect called.");
+        axios.get('http://127.0.0.1:8000/languages/')
+        .then(response => {
+            setallLanguages(response.data);
+        })
+        .catch(error => {
+            console.error('Error fetching data:', error);
+        });
+    }, []);
+
+    // A function to fetch the translations after user enters a question
+    const getQuestionTranslations = (e) => {
+        const question = e.target.value;
+        axios.get(`http://127.0.0.1:8000/translations/question/${question}/`)
+        .then(response => {
+            setTranslatedQuestions(response.data);
+        })
+        .catch(error => {
+            console.error('Error fetching data:', error);
+        });
+      };
+
+    // A function to fetch the translations after user enters answer choices
+    const getAnswersTranslations = (e) => {
+        const answers = e.target.value;
+        // const data = {question: question, answers: answers}
+        axios.get(`http://127.0.0.1:8000/translations/answers/${answers}/`)
+        .then(response => {
+            setTranslatedAnswers(response.data);
+        })
+        .catch(error => {
+            console.error('Error fetching data:', error);
+        });
+    };
+
+    function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers) {
+        if (allLanguages.length !== 0) {
+            return allLanguages.map(obj => {
+                return <div className="row" key={`lang-${obj.abbreviation}`}>
+                            <label htmlFor={`lang-${obj.abbreviation}-question`}>{`${obj.name} Question:`}</label>
+                            <input type="text" id={`lang-${obj.abbreviation}-question`} name={`lang-${obj.abbreviation}-question`}
+                            defaultValue={translatedQuestions[obj.abbreviation] ? `${translatedQuestions[obj.abbreviation]}` : ""}/>
+                            <label htmlFor={`lang-${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</label>
+                            <input type="text" id={`lang-${obj.abbreviation}-answers`} name={`lang-${obj.abbreviation}-answers`}
+                            defaultValue={translatedAnswers[obj.abbreviation] ? `${translatedAnswers[obj.abbreviation]}` : ""}/>
+                       </div>
+            })
+        }
+    }
+
+    return (
+        <div className="container">
+            <form action="/addquestion/submit/" method="post">
+                <div className="row gap-5">
+                    <div className="col">
+                        <div className="row">
+                            <label htmlFor="question">Question:</label>
+                            <input type="text" id="question" name="question" onBlur={getQuestionTranslations}/>
+                        </div>
+                        <div className="row">
+                            <label htmlFor="answers">Answers (comma-separated):</label>
+                            <input type="text" id="answers" name="answers" onBlur={getAnswersTranslations}/>
+                        </div>
+                        <div className="row">
+                            <div className="col">
+                                <div className="row">
+                                    <label htmlFor="hasOther">Has Other:</label>
+                                </div>
+                                <div className="row">
+                                    <div className="col">
+                                        <input type="radio" id="has_other_true" name="has_other" value="true" />
+                                        <label htmlFor="has_other_true">True</label>
+                                    </div>
+                                </div>
+                                <div className="row">
+                                    <div className="col">
+                                        <input type="radio" id="has_other_false" name="has_other" value="false" />
+                                        <label htmlFor="has_other_false">False</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="row">
+                            <div className="col">
+                                <button type="submit">Submit</button>
+                            </div>
+                            {/* <div className="col">
+                                <button type="button" onClick={getTranslations}>Get Translation</button>
+                            </div> */}
+                        </div>
+                    </div>
+                    <div className="col">
+                        {displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers)}
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+export default AddQuestionPage;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 
 import ClientDataForm from "./ClientDataForm";
 import ClientDataTable from "./ClientDataTable";
+import AddQuestionPage from "./AddQuestionPage";
 import LandingPage from "./LandingPage";
 import "bootstrap/dist/css/bootstrap.css";
 
@@ -13,6 +14,7 @@ const App = () => {
         <Route path="/" element={<LandingPage />} />
         <Route path="/form" element={<ClientDataForm />} />
         <Route path="/table" element={<ClientDataTable />} />
+        <Route path="/addQuestion" element={<AddQuestionPage />} />
         {/* Add other routes here */}
       </Routes>
     </Router>


### PR DESCRIPTION
# Describe your changes
Add a `AddQuestionPage.js` in frontend to replace `add_question_form.html` in backend.
The `AddQuestionPage` supports getting translations for questions, answer choices, and the word "other" when user tries to add a new question.
The changes also update the logic to store the new question and its translations into the database.

There is no button on the `LandingPage.js` to access this page yet since we're updating the UI for that but the changes can be tested by going to `http://localhost:3000/addQuestion`.

# Issue ticket number and link
https://github.com/users/smithev95/projects/1/views/1?pane=issue&itemId=69712224

# Testing done
Local UI testing.

# Checklist before requesting a review
[x] I have performed a self-review of my code
[ ] If it is a core feature, I have added thorough tests.