### PR TITLE
Add duplicate check in `AddQuestionPage`

### DIFF
--- a/backend/data_handler_app/admin.py
+++ b/backend/data_handler_app/admin.py
@@ -16,7 +16,7 @@ def add_question(request):
         data = json.loads(request.body)
         try:
             # Add a Question object to Question table
-            question = data['question']
+            question = data['question'].strip()
 
             # Check for duplicated question
             if (Question.objects.filter(question=question, deleted=False).exists()):

--- a/backend/data_handler_app/admin.py
+++ b/backend/data_handler_app/admin.py
@@ -17,6 +17,13 @@ def add_question(request):
         try:
             # Add a Question object to Question table
             question = data['question']
+
+            # Check for duplicated question
+            if (Question.objects.filter(question=question, deleted=False).exists()):
+                return JsonResponse({"status": "error", 
+                                     "message": f"Question already exists in the database."}, 
+                                    status=405)
+
             answer_choices = data['answers'].split(',')
             has_other = False if data['has_other'] == 'false' else True
 

--- a/backend/data_handler_app/views.py
+++ b/backend/data_handler_app/views.py
@@ -28,12 +28,23 @@ def client_data_form(request):
             # Get the OG question from the translated question
             translated_question = TranslatedQuestion.objects.get(question=key)
             question = Question.objects.get(question=translated_question.question_fk)
-            # Get index of answer from translated answer choices
-            answer_index = translated_question.answer_choices.index(value)
-            # Get english answer using same index
-            new_answer = Answer(answer=question.answer_choices[answer_index], question_fk=question, 
-                                client_id=new_id)
-            new_answer.save()
+
+            try: 
+                # Get index of answer from translated answer choices
+                answer_index = translated_question.answer_choices.index(value)
+                # Get English answer using same index
+                new_answer = Answer(answer=question.answer_choices[answer_index], question_fk=question, 
+                                    client_id=new_id)
+                new_answer.save()
+
+            # If value not in translated_question.answer_choices then it's from "other" field
+            except ValueError as e:
+                # Translate the answer to English
+                translation = ts.translate_text(value, translator="google", 
+                                                to_language='en')
+                new_answer = Answer(answer=translation, question_fk=question, 
+                                    client_id=new_id)
+                new_answer.save()
         return HttpResponse({'successfull'}, status=200)  
     except Exception as e:
         return HttpResponse({"status": "error", "message": f"Error saving data: {str(e)}"}, 

--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -115,6 +115,7 @@ const AddQuestionPage = () => {
         })
         .catch((error) => {
             console.error("Error sending data", error);
+            alert(error.response.data.message);
         });
     }
 

--- a/frontend/src/ClientDataForm.js
+++ b/frontend/src/ClientDataForm.js
@@ -35,9 +35,9 @@ const ClientDataForm = () => {
       form_data_object[key] = value;
     });
 
-    // Loop through to check for has_other option
+    // Loop through to check for other option
     questions.forEach((question) => {
-      if (question.has_other) {
+      if (question.other) {
         // If radio value is "Other", use the value from the text field
         if (form_data_object[question.question] === "Other") {
           form_data_object[question.question] =
@@ -50,7 +50,6 @@ const ClientDataForm = () => {
     });
 
     const json_data = JSON.stringify(form_data_object);
-
     axios
       .post("http://127.0.0.1:8000/newsubmission/", json_data, {
         headers: {
@@ -59,8 +58,9 @@ const ClientDataForm = () => {
       })
       .then((response) => {
         if (response.status === 200) {
-          window.location.href = "/selectlanguage";
           console.log("status", response.status);
+          alert("Form successfully submitted!")
+          window.location.href = "/selectlanguage";
         } else {
           console.log("unsuccessful");
         }
@@ -94,7 +94,7 @@ const ClientDataForm = () => {
               <br />
             </Fragment>
           ))}
-          {question.has_other && (
+          {question.other && (
             <div className="form-outline w-25 mb-2">
               <input
                 className="form-check-input"

--- a/frontend/src/SelectQuestionPage.js
+++ b/frontend/src/SelectQuestionPage.js
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
-import { LanguageContext } from "./Contexts/Contexts";
 
 const SelectQuestionPage = () => {
   const [questions, setQuestions] = useState([]);


### PR DESCRIPTION
# Describe your changes

- Add an `if` statement to check in `add_question` whether the same question already exists in the database. If so, a `405` error is returned and an alert appears.
- Add `.strip` to clean up question string before adding in case the user accidentally added leading and trailing spaces.
- I found a bug where the "Other" choice of questions that `has_other=True` wasn't rendering in `ClientDataForm` since we switched from using `Questions` table to `TranslatedQuestions`. So I changed from looking for `has_other` field to looking for `other` field in `ClientDataForm`. I also updated `client_data_form` to be able to translate to English and save the freeform text from the "Other" option into `Answers`.
- I added an alert when form is successfully submitted in `ClientDataForm`.

# Issue ticket number and link
https://github.com/users/smithev95/projects/1/views/1?pane=issue&itemId=71297336

# Testing done

- Tested adding duplicated question, with and without spaces, to ensure that the question won't be added and the alert appears.
- Tested adding non-duplicated question, to ensure that the question is successfully added.
- Tested submitting different language answers through the form and ensuring that the English translations are successfully saved and displayed in `ClientDataTable`.

# Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
