### PR TITLE
TK-74 Update `EditQuestion` and `SelectQuestion` pages frontend with Bootstrap

### DIFF
--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -7,8 +7,8 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
-import Spinner from 'react-bootstrap/Spinner';
 import Card from 'react-bootstrap/Card';
+import TranslateButton from './components/TranslateButton.js';
 
 const AddQuestionPage = () => {
     const [allLanguages, setallLanguages] = useState([]);
@@ -119,57 +119,6 @@ const AddQuestionPage = () => {
         });
     }
 
-    const translateQuestionButton = () =>
-    {
-        if(areQuestionsLoading)
-        {
-            return (
-                <Button variant="primary" disabled>
-                    <Spinner
-                        as="span"
-                        animation="border"
-                        size="sm"
-                        role="status"
-                        aria-hidden="true"
-                    />
-                    &nbsp;&nbsp;Loading...
-                </Button>
-            );
-        }
-        else
-        {
-            return (
-                <Button type="button" onClick={getQuestionTranslations}>Get Translation</Button>
-            );
-        }
-    }
-
-    const translateAnswersButton = () =>
-        {
-            if(areAnswersLoading)
-            {
-                return (
-                    <Button variant="primary" disabled>
-                        <Spinner
-                            as="span"
-                            animation="border"
-                            size="sm"
-                            role="status"
-                            aria-hidden="true"
-                        />
-                        &nbsp;&nbsp;Loading...
-                    </Button>
-                );
-            }
-            else
-            {
-                return (
-                    <Button type="button" onClick={getAnswersTranslations}>Get Translation</Button>
-                );
-            }
-        }
-
-
     function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers) {
         if (allLanguages.length !== 0) {
             return allLanguages.map(obj => {
@@ -222,7 +171,7 @@ const AddQuestionPage = () => {
                         </Col>
                         <Row>
                             <Col sm="6">
-                                {translateQuestionButton()}
+                                <TranslateButton loading={areQuestionsLoading} func={getQuestionTranslations} />
                             </Col>
                         </Row>                                
                     </Form.Group>
@@ -239,7 +188,7 @@ const AddQuestionPage = () => {
                         </Col>
                         <Row>
                             <Col sm="6">
-                                {translateAnswersButton()}
+                                <TranslateButton loading={areAnswersLoading} func={getAnswersTranslations} />
                             </Col>
                         </Row>                                
                     </Form.Group>

--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -7,8 +7,8 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
-import Card from 'react-bootstrap/Card';
 import TranslateButton from './components/TranslateButton.js';
+import TranslatedTextCards from './components/TranslatedTextCards.js';
 
 const AddQuestionPage = () => {
     const [allLanguages, setallLanguages] = useState([]);
@@ -119,39 +119,6 @@ const AddQuestionPage = () => {
         });
     }
 
-    function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers) {
-        if (allLanguages.length !== 0) {
-            return allLanguages.map(obj => {
-                return  <Card border="primary" key={`${obj.abbreviation}`}>
-                            <Card.Title className="text-center">{`${obj.name}`}</Card.Title>
-                            <Card.Body>
-                                <Form.Label htmlFor={`${obj.abbreviation}-question`}>{`${obj.name} Question:`}</Form.Label>
-                                <Form.Control 
-                                    type="text" 
-                                    id={`${obj.abbreviation}-question`}
-                                    name={`${obj.abbreviation}-question`}
-                                    defaultValue={translatedQuestions[obj.abbreviation] ? `${translatedQuestions[obj.abbreviation]}` : ""}
-                                />
-                                <Form.Label htmlFor={`${obj.abbreviation}-other`}>{`${obj.name} "Other":`}</Form.Label>
-                                <Form.Control 
-                                    type="text" 
-                                    id={`${obj.abbreviation}-other`}
-                                    name={`${obj.abbreviation}-other`}
-                                    defaultValue={translatedOthers[obj.abbreviation] ? `${translatedOthers[obj.abbreviation]}` : ""}
-                                />
-                                <Form.Label htmlFor={`${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</Form.Label>
-                                <Form.Control 
-                                    type="text" 
-                                    id={`${obj.abbreviation}-answers`}
-                                    name={`${obj.abbreviation}-answers`}
-                                    defaultValue={translatedAnswers[obj.abbreviation] ? `${translatedAnswers[obj.abbreviation]}` : ""}
-                                />
-                            </Card.Body>
-                        </Card>
-            })
-        }
-    }
-
     return (
         <>
         <NavbarMenu />
@@ -221,7 +188,12 @@ const AddQuestionPage = () => {
                     </Row>
                 </Row>
                 <Row className="g-4" xs={1} lg={2} xxl={3}>
-                    {displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers)}
+                    <TranslatedTextCards 
+                        langs={allLanguages} 
+                        questions={translatedQuestions}
+                        answers={translatedAnswers}
+                        others={translatedOthers}
+                    />
                 </Row>
             </Form>
         </Container>

--- a/frontend/src/AddQuestionPage.js
+++ b/frontend/src/AddQuestionPage.js
@@ -108,6 +108,8 @@ const AddQuestionPage = () => {
         .then((response) => {
             if (response.status === 200) {
                 console.log("status", response.status);
+                alert("New question is successfully added!")
+                window.location.href = "/addQuestion";
             } 
             else {
                 console.log("unsuccessful");

--- a/frontend/src/EditQuestionPage.js
+++ b/frontend/src/EditQuestionPage.js
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import 'bootstrap/dist/css/bootstrap.css';
+import NavbarMenu from './components/Navbar.js';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import TranslateButton from './components/TranslateButton.js';
 
 const EditQuestionPage = () => {
     const location = useLocation();
@@ -12,6 +21,8 @@ const EditQuestionPage = () => {
     const [translatedQuestions, setTranslatedQuestions] = useState({});
     const [translatedAnswers, setTranslatedAnswers] = useState({});
     const [translatedOthers, setTranslatedOther] = useState({});
+    const [areQuestionsLoading, setQuestionsLoading] = useState(false);
+    const [areAnswersLoading, setAnswersLoading] = useState(false);
     let navigate = useNavigate();
 
     // Fetch language data
@@ -44,11 +55,14 @@ const EditQuestionPage = () => {
     // A function to fetch the translations after user enters a question
     const getQuestionTranslations = () => {
         if (question !== "") {
+            setQuestionsLoading(true);
             axios.get(`http://127.0.0.1:8000/translations/?question=${question}`)
             .then(response => {
                 setTranslatedQuestions(response.data);
+                setQuestionsLoading(false);
             })
             .catch(error => {
+                setQuestionsLoading(false);
                 console.error('Error fetching data:', error);
             });
         }
@@ -57,11 +71,14 @@ const EditQuestionPage = () => {
     // A function to fetch the translations after user enters answer choices
     const getAnswersTranslations = () => {
         if (answers !== "") {
+            setAnswersLoading(true);
             axios.get(`http://127.0.0.1:8000/translations/?answers=${answers}`)
             .then(response => {
                 setTranslatedAnswers(response.data);
+                setAnswersLoading(false);
             })
             .catch(error => {
+                setAnswersLoading(false);
                 console.error('Error fetching data:', error);
             });
         }
@@ -154,80 +171,112 @@ const EditQuestionPage = () => {
     function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers) {
         if (allLanguages.length !== 0) {
             return allLanguages.map(obj => {
-                return <div className="row py-3" key={`${obj.abbreviation}`}>
-                            <label htmlFor={`${obj.abbreviation}-question`}>{`${obj.name} Question:`}</label>
-                            <input type="text" id={`${obj.abbreviation}-question`} name={`${obj.abbreviation}-question`}
-                            defaultValue={translatedQuestions[obj.abbreviation] ? `${translatedQuestions[obj.abbreviation]}` : ""}/>
-                            <label htmlFor={`${obj.abbreviation}-other`}>{`${obj.name} "Other":`}</label>
-                            <input type="text" id={`${obj.abbreviation}-other`} name={`${obj.abbreviation}-other`}
-                            defaultValue={translatedOthers[obj.abbreviation] ? `${translatedOthers[obj.abbreviation]}` : ""}/>
-                            <label htmlFor={`${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</label>
-                            <input type="text" id={`${obj.abbreviation}-answers`} name={`${obj.abbreviation}-answers`}
-                            defaultValue={translatedAnswers[obj.abbreviation] ? `${translatedAnswers[obj.abbreviation]}` : ""}/>
-                       </div>
+                return  <Card border="primary" key={`${obj.abbreviation}`}>
+                            <Card.Title className="text-center">{`${obj.name}`}</Card.Title>
+                            <Card.Body>
+                                <Form.Label htmlFor={`${obj.abbreviation}-question`}>{`${obj.name} Question:`}</Form.Label>
+                                <Form.Control 
+                                    type="text" 
+                                    id={`${obj.abbreviation}-question`}
+                                    name={`${obj.abbreviation}-question`}
+                                    defaultValue={translatedQuestions[obj.abbreviation] ? `${translatedQuestions[obj.abbreviation]}` : ""}
+                                />
+                                <Form.Label htmlFor={`${obj.abbreviation}-other`}>{`${obj.name} "Other":`}</Form.Label>
+                                <Form.Control 
+                                    type="text" 
+                                    id={`${obj.abbreviation}-other`}
+                                    name={`${obj.abbreviation}-other`}
+                                    defaultValue={translatedOthers[obj.abbreviation] ? `${translatedOthers[obj.abbreviation]}` : ""}
+                                />
+                                <Form.Label htmlFor={`${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</Form.Label>
+                                <Form.Control 
+                                    type="text" 
+                                    id={`${obj.abbreviation}-answers`}
+                                    name={`${obj.abbreviation}-answers`}
+                                    defaultValue={translatedAnswers[obj.abbreviation] ? `${translatedAnswers[obj.abbreviation]}` : ""}
+                                />
+                            </Card.Body>
+                        </Card>
             })
         }
     }
 
     return (
-        <div className="container">
-            <form method="post" onSubmit={handleSubmit}>
-                <div className="row gap-5">
-                    <div className="col">
-                        <div className="row py-3">
-                            <label htmlFor="question">Question:</label>
-                            <input type="text" id="question" name="question" 
-                            onBlur={(e) => setQuestion(e.target.value)} defaultValue={question}/>
-                            <div className="col py-3">
-                                <button type="button" onClick={getQuestionTranslations}>Get Translation</button>
-                            </div>
-                        </div>
-                        <div className="row py-3">
-                            <label htmlFor="answers">Answers (comma-separated):</label>
-                            <input type="text" id="answers" name="answers" 
-                            onBlur={(e) => setAnswers(e.target.value)} defaultValue={answers}/>
-                            <div className="col py-3">
-                                <button type="button" onClick={getAnswersTranslations}>Get Translation</button>
-                            </div>
-                        </div>
-                        <div className="row py-3">
-                            <div className="col">
-                                <div className="row">
-                                    <label htmlFor="hasOther">Has Other:</label>
-                                </div>
-                                <div className="row">
-                                    <div className="col">
-                                        <input type="radio" id="has_other_true" name="has_other" value="true" 
-                                        onChange={handleHasOtherClick}
-                                        checked={hasOther}/>
-                                        <label htmlFor="has_other_true">True</label>
-                                    </div>
-                                </div>
-                                <div className="row">
-                                    <div className="col">
-                                        <input type="radio" id="has_other_false" name="has_other" value="false" 
-                                        onChange={handleHasOtherClick} 
-                                        checked={!hasOther}/>
-                                        <label htmlFor="has_other_false">False</label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div className="row py-3">
-                            <div className="col">
-                                <button type="submit" value="update">Update</button>
-                            </div>
-                            <div className="col">
-                                <button type="submit" value="delete">Delete</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div className="col">
+        <>
+            <NavbarMenu />
+            <Container>
+                <Form method="post" onSubmit={handleSubmit}> 
+                    <Row className="py-3">
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label htmlFor="question" column sm="2" lg="1">Question:</Form.Label>
+                            <Col sm="10" lg="6">
+                                <Form.Control className="mb-3"
+                                    type="text"
+                                    id="question"
+                                    name="question"
+                                    defaultValue={question}
+                                    onBlur={(e) => setQuestion(e.target.value)}   
+                                />
+                            </Col>
+                            <Row>
+                                <Col sm="6">
+                                    <TranslateButton loading={areQuestionsLoading} func={getQuestionTranslations} />
+                                </Col>
+                            </Row>                                
+                        </Form.Group>
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label htmlFor="answers" column sm="2" lg="1">Answers:</Form.Label>
+                            <Col sm="10" lg="6">
+                                <Form.Control className="mb-3"
+                                    type="text"
+                                    id="answers"
+                                    name="answers"
+                                    defaultValue={answers}
+                                    onBlur={(e) => setAnswers(e.target.value)}   
+                                />
+                            </Col>
+                            <Row>
+                                <Col sm="6">
+                                    <TranslateButton loading={areAnswersLoading} func={getAnswersTranslations} />
+                                </Col>
+                            </Row>                                
+                        </Form.Group>
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label htmlFor="hasOther" column sm="4">Has Other:</Form.Label>
+                            <Form.Check
+                                checked={hasOther}
+                                type="radio"
+                                htmlFor="has_other_true"
+                                id="has_other_true"
+                                name="has_other"
+                                value="true"
+                                label="True"
+                                onClick={handleHasOtherClick}  
+                            />
+                            <Form.Check
+                                checked={!hasOther}
+                                type="radio"
+                                htmlFor="has_other_false"
+                                id="has_other_false"
+                                name="has_other"
+                                value="false"
+                                label="False"
+                                onClick={handleHasOtherClick}  
+                            />                              
+                        </Form.Group>
+                        <Row>
+                            <Col sm="6">
+                                <Button className="me-4" type="submit" value="update">Update</Button>
+                                <Button type="submit" value="delete">Delete</Button>
+                            </Col>
+                        </Row>
+                    </Row>
+                    <Row className="g-4" xs={1} lg={2} xxl={3}>
                         {displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers)}
-                    </div>
-                </div>
-            </form>
-        </div>
+                    </Row>
+                </Form>
+            </Container>
+        </>
     );
 }
 

--- a/frontend/src/EditQuestionPage.js
+++ b/frontend/src/EditQuestionPage.js
@@ -8,8 +8,8 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
-import Card from 'react-bootstrap/Card';
 import TranslateButton from './components/TranslateButton.js';
+import TranslatedTextCards from './components/TranslatedTextCards.js';
 
 const EditQuestionPage = () => {
     const location = useLocation();
@@ -168,39 +168,6 @@ const EditQuestionPage = () => {
         }
     }
 
-    function displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers) {
-        if (allLanguages.length !== 0) {
-            return allLanguages.map(obj => {
-                return  <Card border="primary" key={`${obj.abbreviation}`}>
-                            <Card.Title className="text-center">{`${obj.name}`}</Card.Title>
-                            <Card.Body>
-                                <Form.Label htmlFor={`${obj.abbreviation}-question`}>{`${obj.name} Question:`}</Form.Label>
-                                <Form.Control 
-                                    type="text" 
-                                    id={`${obj.abbreviation}-question`}
-                                    name={`${obj.abbreviation}-question`}
-                                    defaultValue={translatedQuestions[obj.abbreviation] ? `${translatedQuestions[obj.abbreviation]}` : ""}
-                                />
-                                <Form.Label htmlFor={`${obj.abbreviation}-other`}>{`${obj.name} "Other":`}</Form.Label>
-                                <Form.Control 
-                                    type="text" 
-                                    id={`${obj.abbreviation}-other`}
-                                    name={`${obj.abbreviation}-other`}
-                                    defaultValue={translatedOthers[obj.abbreviation] ? `${translatedOthers[obj.abbreviation]}` : ""}
-                                />
-                                <Form.Label htmlFor={`${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</Form.Label>
-                                <Form.Control 
-                                    type="text" 
-                                    id={`${obj.abbreviation}-answers`}
-                                    name={`${obj.abbreviation}-answers`}
-                                    defaultValue={translatedAnswers[obj.abbreviation] ? `${translatedAnswers[obj.abbreviation]}` : ""}
-                                />
-                            </Card.Body>
-                        </Card>
-            })
-        }
-    }
-
     return (
         <>
             <NavbarMenu />
@@ -272,7 +239,12 @@ const EditQuestionPage = () => {
                         </Row>
                     </Row>
                     <Row className="g-4" xs={1} lg={2} xxl={3}>
-                        {displayTranslatedText(allLanguages, translatedQuestions, translatedAnswers, translatedOthers)}
+                        <TranslatedTextCards 
+                            langs={allLanguages} 
+                            questions={translatedQuestions}
+                            answers={translatedAnswers}
+                            others={translatedOthers}
+                        />
                     </Row>
                 </Form>
             </Container>

--- a/frontend/src/EditQuestionPage.js
+++ b/frontend/src/EditQuestionPage.js
@@ -133,6 +133,7 @@ const EditQuestionPage = () => {
             .then((response) => {
                 if (response.status === 200) {
                     console.log("status", response.status);
+                    alert("Question is successfully updated!");
                     navigate("/selectQuestion");
                 } 
                 else {
@@ -156,6 +157,7 @@ const EditQuestionPage = () => {
             .then((response) => {
                 if (response.status === 200) {
                     console.log("status", response.status);
+                    alert("Question is successfully deleted!");
                     navigate("/selectQuestion");
                 } 
                 else {

--- a/frontend/src/SelectQuestionPage.js
+++ b/frontend/src/SelectQuestionPage.js
@@ -1,6 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
+import NavbarMenu from './components/Navbar.js';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import 'bootstrap/dist/css/bootstrap.css';
 
 const SelectQuestionPage = () => {
   const [questions, setQuestions] = useState([]);
@@ -31,35 +38,44 @@ const SelectQuestionPage = () => {
 
   function displayQuestions(questions) {
     if (questions.length !== 0) {
-      return questions.map((obj) => {
         return (
-          <div className="row py-1" key={`${obj.id}`}>
-            <div className="col">
-              <input
-                type="radio"
-                name="question"
-                id={`${obj.id}`}
-                value={`${obj.id}`}
-                onChange={onOptionChange}
-              />
-              <label htmlFor={`${obj.id}`}> {`${obj.question}`}</label>
-            </div>
-          </div>
+            <Form>
+                {questions.map((obj) => (
+                    <div key={`${obj.id}`}>
+                        <Form.Check
+                            type="radio"
+                            name="question"
+                            label={`${obj.question}`}
+                            id={`${obj.id}`}
+                            value={`${obj.id}`}
+                            onChange={onOptionChange}
+                        />
+                    </div>
+                ))}
+            </Form>
         );
-      });
     }
   }
 
   return (
-    <div className="container">
-      <div className="row py-3">Select a question to delete or update:</div>
-      {displayQuestions(questions)}
-      <div className="row py-3">
-        <div className="col">
-          <button onClick={handleSelect}>Select</button>
-        </div>
-      </div>
-    </div>
+    <>
+        <NavbarMenu />
+        <Container>
+            <Row className="py-3">
+                <Col>Select a question to delete or update:</Col>
+            </Row>
+            <Row>
+                <Col>
+                    {displayQuestions(questions)}
+                </Col>
+            </Row>
+            <Row className="py-3">
+                <Col>
+                    <Button onClick={handleSelect}>Select</Button>
+                </Col>
+            </Row>
+        </Container>
+    </>
   );
 };
 

--- a/frontend/src/components/TranslateButton.js
+++ b/frontend/src/components/TranslateButton.js
@@ -1,0 +1,24 @@
+import Button from 'react-bootstrap/Button';
+import Spinner from 'react-bootstrap/Spinner';
+
+const TranslateButton = ({loading, func}) => {
+    if (loading) {
+        return (
+            <Button variant="primary" disabled>
+                <Spinner
+                    as="span"
+                    animation="border"
+                    size="sm"
+                    role="status"
+                    aria-hidden="true"
+                />
+                &nbsp;&nbsp;Loading...
+            </Button>
+        );
+    }
+    else {
+        return <Button type="button" onClick={func}>Get Translation</Button> 
+    }
+  };
+  
+  export default TranslateButton;

--- a/frontend/src/components/TranslatedTextCards.js
+++ b/frontend/src/components/TranslatedTextCards.js
@@ -1,0 +1,39 @@
+import Card from 'react-bootstrap/Card';
+import Form from 'react-bootstrap/Form';
+
+const TranslatedTextCards = ({langs, questions, answers, others}) => {
+    if (langs.length !== 0) {
+        return (
+            langs.map((obj) => (
+                <Card border="primary" key={`${obj.abbreviation}`}>
+                        <Card.Title className="text-center">{`${obj.name}`}</Card.Title>
+                        <Card.Body>
+                            <Form.Label htmlFor={`${obj.abbreviation}-question`}>{`${obj.name} Question:`}</Form.Label>
+                            <Form.Control 
+                                type="text" 
+                                id={`${obj.abbreviation}-question`}
+                                name={`${obj.abbreviation}-question`}
+                                defaultValue={questions[obj.abbreviation] ? `${questions[obj.abbreviation]}` : ""}
+                            />
+                            <Form.Label htmlFor={`${obj.abbreviation}-other`}>{`${obj.name} "Other":`}</Form.Label>
+                            <Form.Control 
+                                type="text" 
+                                id={`${obj.abbreviation}-other`}
+                                name={`${obj.abbreviation}-other`}
+                                defaultValue={others[obj.abbreviation] ? `${others[obj.abbreviation]}` : ""}
+                            />
+                            <Form.Label htmlFor={`${obj.abbreviation}-answers`}>{`${obj.name} Answers:`}</Form.Label>
+                            <Form.Control 
+                                type="text" 
+                                id={`${obj.abbreviation}-answers`}
+                                name={`${obj.abbreviation}-answers`}
+                                defaultValue={answers[obj.abbreviation] ? `${answers[obj.abbreviation]}` : ""}
+                            />
+                        </Card.Body>
+                    </Card>
+            ))
+        );
+    }
+  };
+  
+  export default TranslatedTextCards;


### PR DESCRIPTION
# Describe your changes
- Made the Translation Button and Translated Text Cards separate components to make re-use easier in `EditQuestion` and `AddQuestion` pages.
- Apply Bootstrap to `SelectQuestion` and `EditQuestionPage` so that they look the same as `AddQuestionPage`.

# Issue ticket number and link
https://github.com/users/smithev95/projects/1/views/1?pane=issue&itemId=71852318

# Testing done
- Ensured that the frontend looks consistent across the `EditQuestion`, `SelectQuestion`, and `AddQuestion` pages.
- Tested that the admin operations to add, update, and delete questions remain intact with the frontend changes.

# Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I add comments where necessary and ensure consistent formatting of codebase
